### PR TITLE
CTRLS-21 화면 확대 및 레벨 시간 추가

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -23,9 +23,9 @@ import screen.TitleScreen;
 public final class Core {
 
 	/** Width of current screen. */
-	private static final int WIDTH = 448;
+	private static final int WIDTH = 720;
 	/** Height of current screen. */
-	private static final int HEIGHT = 520;
+	private static final int HEIGHT = WIDTH + 40;
 	/** Max fps of current screen. */
 	private static final int FPS = 60;
 

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -563,4 +563,23 @@ public final class DrawManager {
 			drawCenteredBigString(screen, "GO!", screen.getHeight() / 2
 					+ fontBigMetrics.getHeight() / 3);
 	}
+
+	/**
+	 * 레벨 시작 후 경과 시간을 화면 상단 중앙에 표시합니다.
+	 *
+	 * @param screen 화면 객체입니다.
+	 * @param elapsedTime 경과 시간(초)입니다.
+	 */
+	public void drawTime(final Screen screen, final int elapsedTime) {
+		backBufferGraphics.setFont(fontRegular);
+		backBufferGraphics.setColor(Color.WHITE);
+		String timeString = elapsedTime + "S";
+
+		// 문자열의 너비를 계산하여 중앙에 위치시킵니다.
+		int xPosition = (screen.getWidth() - fontRegularMetrics.stringWidth(timeString)) / 2;
+		// Y 좌표는 원하는 위치로 설정합니다. 여기서는 상단 여백을 25로 설정했습니다.
+		int yPosition = 25;
+
+		backBufferGraphics.drawString(timeString, xPosition, yPosition);
+	}
 }

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -573,7 +573,7 @@ public final class DrawManager {
 	public void drawTime(final Screen screen, final int elapsedTime) {
 		backBufferGraphics.setFont(fontRegular);
 		backBufferGraphics.setColor(Color.WHITE);
-		String timeString = elapsedTime + "S";
+		String timeString = elapsedTime + " S";
 
 		// 문자열의 너비를 계산하여 중앙에 위치시킵니다.
 		int xPosition = (screen.getWidth() - fontRegularMetrics.stringWidth(timeString)) / 2;

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -70,10 +70,12 @@ public class GameScreen extends Screen {
 	private boolean levelFinished;
 	/** Checks if a bonus life is received. */
 	private boolean bonusLife;
-	/** level 이 시작된 실제 시간 */
-	private long levelStartTime;
+	/** level 경과 시간 */
+	private int levelTime;
 	/** level 이 시작 되었는지 여부 */
 	private boolean levelStarted;
+	/** 1초를 새는 Cooldown */
+	private Cooldown clockCooldown;
 
 	/**
 	 * Constructor, establishes the properties of the screen.
@@ -132,6 +134,9 @@ public class GameScreen extends Screen {
 
 		// GameScreen 이 시작될 땐 카운트 다운이 시작되므로
 		this.levelStarted = false;
+		this.levelTime = 0;
+		this.clockCooldown = Core.getCooldown(1000);
+		this.clockCooldown.reset();
 	}
 
 	/**
@@ -154,9 +159,9 @@ public class GameScreen extends Screen {
 	protected final void update() {
 		super.update();
 
-		// Check if the input delay has finished and the level hasn't started yet
+		// level 이 처음 시작될 때 clockCooldown reset
 		if (this.inputDelay.checkFinished() && !this.levelStarted) {
-			this.levelStartTime = System.currentTimeMillis();
+			this.clockCooldown.reset();
 			this.levelStarted = true;
 		}
 
@@ -220,6 +225,12 @@ public class GameScreen extends Screen {
 			this.ship.update();
 			this.enemyShipFormation.update();
 			this.enemyShipFormation.shoot(this.bullets);
+
+			// 1초마다 levelTime 1씩 증가
+			if (this.clockCooldown.checkFinished()) {
+				this.levelTime += 1;
+				this.clockCooldown.reset();
+			}
 		}
 
 		manageCollisions();
@@ -270,11 +281,8 @@ public class GameScreen extends Screen {
 					this.bonusLife);
 		}
 
-		// Display elapsed time since the level started
-		if (this.levelStarted) {
-			int elapsedTime = (int) ((System.currentTimeMillis() - this.levelStartTime) / 1000);
-			drawManager.drawTime(this, elapsedTime);
-		}
+		// 현재 levelTime 그리기
+		drawManager.drawTime(this, levelTime);
 
 		drawManager.completeDrawing(this);
 	}

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -70,6 +70,10 @@ public class GameScreen extends Screen {
 	private boolean levelFinished;
 	/** Checks if a bonus life is received. */
 	private boolean bonusLife;
+	/** level 이 시작된 실제 시간 */
+	private long levelStartTime;
+	/** level 이 시작 되었는지 여부 */
+	private boolean levelStarted;
 
 	/**
 	 * Constructor, establishes the properties of the screen.
@@ -125,6 +129,9 @@ public class GameScreen extends Screen {
 		this.gameStartTime = System.currentTimeMillis();
 		this.inputDelay = Core.getCooldown(INPUT_DELAY);
 		this.inputDelay.reset();
+
+		// GameScreen 이 시작될 땐 카운트 다운이 시작되므로
+		this.levelStarted = false;
 	}
 
 	/**
@@ -146,6 +153,12 @@ public class GameScreen extends Screen {
 	 */
 	protected final void update() {
 		super.update();
+
+		// Check if the input delay has finished and the level hasn't started yet
+		if (this.inputDelay.checkFinished() && !this.levelStarted) {
+			this.levelStartTime = System.currentTimeMillis();
+			this.levelStarted = true;
+		}
 
 		if (this.inputDelay.checkFinished() && !this.levelFinished) {
 
@@ -255,6 +268,12 @@ public class GameScreen extends Screen {
 							- this.gameStartTime)) / 1000);
 			drawManager.drawCountDown(this, this.level, countdown,
 					this.bonusLife);
+		}
+
+		// Display elapsed time since the level started
+		if (this.levelStarted) {
+			int elapsedTime = (int) ((System.currentTimeMillis() - this.levelStartTime) / 1000);
+			drawManager.drawTime(this, elapsedTime);
 		}
 
 		drawManager.completeDrawing(this);


### PR DESCRIPTION
## 개요

- 스크린 크기 확대
- 레벨 경과 시간 추가
- DrawManager.drawTime 메소드 추가

## 작업사항

- Core.WIDTH 값 448 -> 720 변경
- Core.HEIGHT 값 520 -> WIDTH + 40 으로 변경
- 게임 플레이 화면을 1대 1 비율로 만들기 위해 Separation line height 만큼을 HEIGHT 값에 추가함

## 변경로직

- GameScreen에 levelTime, levelStarted 필드 생성
- levelStarted가 true가 된 이후 부터 levelFinished가 true가 될 때까지 levelTime값을 1씩 증가
- drawTime 메소드를 통해 현재 경과 시간 표시

## 참고사항

- 화면 확장
<img width="832" alt="화면 확장" src="https://github.com/user-attachments/assets/be7635b1-46ff-43a7-98aa-fcbc2e9ff5f5">

- 레벨 타임
<img width="832" alt="레벨타임1" src="https://github.com/user-attachments/assets/cc1d2c02-f8a6-4178-ada8-d8645fd62c6c">

<img width="832" alt="레벨타임2" src="https://github.com/user-attachments/assets/c8d3b9f9-71dd-428c-b964-b8ab6bbecd67">

- 관련 이슈 번호: #CTRLS-21
