### PR TITLE
[CTRLS-9] 함선의 4 방향 공격 구현

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -255,7 +255,7 @@ public final class DrawManager {
 		backBufferGraphics.setFont(fontRegular);
 		backBufferGraphics.setColor(Color.WHITE);
 		backBufferGraphics.drawString(Integer.toString(lives), 20, 25);
-		Ship dummyShip = new Ship(0, 0);
+		Ship dummyShip = new Ship(0, 0, "UP");
 		for (int i = 0; i < lives; i++)
 			drawEntity(dummyShip, 40 + 35 * i, 10);
 	}

--- a/src/entity/Bullet.java
+++ b/src/entity/Bullet.java
@@ -17,7 +17,7 @@ public class Bullet extends Entity {
 	 */
 	private int speed;
 	// 총알의 뱡향
-	private String Direction;
+	private String direction;
 	// 아군 또는 적 함선이 발사한 총알을 구분하는 식별자
 	private int classify;
 
@@ -30,16 +30,16 @@ public class Bullet extends Entity {
 	 *            Initial position of the bullet in the Y axis.
 	 * @param speed
 	 *            Speed of the bullet.
-	 * @param Direction
+	 * @param direction
 	 * 			  총알의 방향.
 	 * @param classify
 	 * 			  총알의 진영.
 	 */
-	public Bullet(final int positionX, final int positionY, final int speed, String Direction, String classify) {
+	public Bullet(final int positionX, final int positionY, final int speed, String direction, String classify) {
 		super(positionX, positionY, 3 * 2, 5 * 2, Color.WHITE);
 
 		this.classify = classify.equals("ENEMY") ? 1 : 0; // 아군 SHIP : 0, 적군 ENEMY : 1
-		this.Direction = Direction;
+		this.direction = direction;
 		this.speed = speed;
 		setSprite();
 	}
@@ -58,7 +58,7 @@ public class Bullet extends Entity {
 	 * Updates the bullet's position.
 	 */
 	public final void update() {
-		switch (Direction) {
+		switch (direction) {
 			case "UP" :
 				this.positionY -= this.speed;
 				break;
@@ -96,11 +96,11 @@ public class Bullet extends Entity {
 	/**
 	 * 총알의 방향을 설정하는 Setter.
 	 *
-	 * @param Direction
+	 * @param direction
 	 *            총알의 새로운 방향.
 	 */
-	public final void setDirection(String Direction) {
-		this.Direction = Direction;
+	public final void setDirection(String direction) {
+		this.direction = direction;
 	}
 
 	/**
@@ -109,7 +109,7 @@ public class Bullet extends Entity {
 	 * @return 총알의 방향.
 	 */
 	public String getDirection() {
-		return this.Direction;
+		return this.direction;
 	}
 
 	/**

--- a/src/entity/Bullet.java
+++ b/src/entity/Bullet.java
@@ -13,10 +13,13 @@ import engine.DrawManager.SpriteType;
 public class Bullet extends Entity {
 
 	/**
-	 * Speed of the bullet, positive or negative depending on direction -
-	 * positive is down.
+	 * Speed of the bullet
 	 */
 	private int speed;
+	// 총알의 뱡향
+	private String Direction;
+	// 아군 또는 적 함선이 발사한 총알을 구분하는 식별자
+	private int classify;
 
 	/**
 	 * Constructor, establishes the bullet's properties.
@@ -26,12 +29,17 @@ public class Bullet extends Entity {
 	 * @param positionY
 	 *            Initial position of the bullet in the Y axis.
 	 * @param speed
-	 *            Speed of the bullet, positive or negative depending on
-	 *            direction - positive is down.
+	 *            Speed of the bullet.
+	 * @param Direction
+	 * 			  총알의 방향.
+	 * @param classify
+	 * 			  총알의 진영.
 	 */
-	public Bullet(final int positionX, final int positionY, final int speed) {
+	public Bullet(final int positionX, final int positionY, final int speed, String Direction, String classify) {
 		super(positionX, positionY, 3 * 2, 5 * 2, Color.WHITE);
 
+		this.classify = classify.equals("ENEMY") ? 1 : 0; // 아군 SHIP : 0, 적군 ENEMY : 1
+		this.Direction = Direction;
 		this.speed = speed;
 		setSprite();
 	}
@@ -40,7 +48,7 @@ public class Bullet extends Entity {
 	 * Sets correct sprite for the bullet, based on speed.
 	 */
 	public final void setSprite() {
-		if (speed < 0)
+		if (this.classify == 0)
 			this.spriteType = SpriteType.Bullet;
 		else
 			this.spriteType = SpriteType.EnemyBullet;
@@ -50,12 +58,25 @@ public class Bullet extends Entity {
 	 * Updates the bullet's position.
 	 */
 	public final void update() {
-		this.positionY += this.speed;
+		switch (Direction) {
+			case "UP" :
+				this.positionY -= this.speed;
+				break;
+			case "DOWN" :
+				this.positionY += this.speed;
+				break;
+			case "RIGHT" :
+				this.positionX += this.speed;
+				break;
+			case "LEFT" :
+				this.positionX -= this.speed;
+				break;
+		}
 	}
 
 	/**
 	 * Setter of the speed of the bullet.
-	 * 
+	 *
 	 * @param speed
 	 *            New speed of the bullet.
 	 */
@@ -65,10 +86,47 @@ public class Bullet extends Entity {
 
 	/**
 	 * Getter for the speed of the bullet.
-	 * 
+	 *
 	 * @return Speed of the bullet.
 	 */
 	public final int getSpeed() {
 		return this.speed;
+	}
+
+	/**
+	 * 총알의 방향을 설정하는 Setter.
+	 *
+	 * @param Direction
+	 *            총알의 새로운 방향.
+	 */
+	public final void setDirection(String Direction) {
+		this.Direction = Direction;
+	}
+
+	/**
+	 * 총알의 방향을 얻는 Getter.
+	 *
+	 * @return 총알의 방향.
+	 */
+	public String getDirection() {
+		return this.Direction;
+	}
+
+	/**
+	 * 총알의 진영을 설정하는 Setter.
+	 *
+	 * @param classify 총알의 진영
+	 */
+	public void setClassify(String classify) {
+		this.classify = classify.equals("ENEMY") ? 1 : 0; // 아군 SHIP : 0, 적군 ENEMY : 1
+	}
+
+	/**
+	 * 총알의 진영을 얻는 Getter.
+	 *
+	 * @return 총알의 진영.
+	 */
+	public int getClassify() {
+		return this.classify;
 	}
 }

--- a/src/entity/BulletPool.java
+++ b/src/entity/BulletPool.java
@@ -30,12 +30,15 @@ public final class BulletPool {
 	 * @param positionY
 	 *            Requested position of the bullet in the Y axis.
 	 * @param speed
-	 *            Requested speed of the bullet, positive or negative depending
-	 *            on direction - positive is down.
+	 *            Requested speed of the bullet.
+	 * @param Direction
+	 * 			  설정할 총알의 방향.
+	 * @param classify
+	 * 			  설정할 총할의 진영.
 	 * @return Requested bullet.
 	 */
 	public static Bullet getBullet(final int positionX,
-			final int positionY, final int speed) {
+			final int positionY, final int speed, String Direction, String classify) {
 		Bullet bullet;
 		if (!pool.isEmpty()) {
 			bullet = pool.iterator().next();
@@ -44,8 +47,10 @@ public final class BulletPool {
 			bullet.setPositionY(positionY);
 			bullet.setSpeed(speed);
 			bullet.setSprite();
+			bullet.setDirection(Direction);
+			bullet.setClassify(classify);
 		} else {
-			bullet = new Bullet(positionX, positionY, speed);
+			bullet = new Bullet(positionX, positionY, speed, Direction, classify);
 			bullet.setPositionX(positionX - bullet.getWidth() / 2);
 		}
 		return bullet;

--- a/src/entity/BulletPool.java
+++ b/src/entity/BulletPool.java
@@ -31,14 +31,14 @@ public final class BulletPool {
 	 *            Requested position of the bullet in the Y axis.
 	 * @param speed
 	 *            Requested speed of the bullet.
-	 * @param Direction
+	 * @param direction
 	 * 			  설정할 총알의 방향.
 	 * @param classify
 	 * 			  설정할 총할의 진영.
 	 * @return Requested bullet.
 	 */
 	public static Bullet getBullet(final int positionX,
-			final int positionY, final int speed, String Direction, String classify) {
+			final int positionY, final int speed, String direction, String classify) {
 		Bullet bullet;
 		if (!pool.isEmpty()) {
 			bullet = pool.iterator().next();
@@ -47,10 +47,10 @@ public final class BulletPool {
 			bullet.setPositionY(positionY);
 			bullet.setSpeed(speed);
 			bullet.setSprite();
-			bullet.setDirection(Direction);
+			bullet.setDirection(direction);
 			bullet.setClassify(classify);
 		} else {
-			bullet = new Bullet(positionX, positionY, speed, Direction, classify);
+			bullet = new Bullet(positionX, positionY, speed, direction, classify);
 			bullet.setPositionX(positionX - bullet.getWidth() / 2);
 		}
 		return bullet;

--- a/src/entity/EnemyShipFormation.java
+++ b/src/entity/EnemyShipFormation.java
@@ -309,7 +309,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 		if (this.shootingCooldown.checkFinished()) {
 			this.shootingCooldown.reset();
 			bullets.add(BulletPool.getBullet(shooter.getPositionX()
-					+ shooter.width / 2, shooter.getPositionY(), BULLET_SPEED));
+					+ shooter.width / 2, shooter.getPositionY(), BULLET_SPEED, null, "ENEMY"));
 		}
 	}
 

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -22,8 +22,7 @@ public class Ship extends Entity {
 	/** Movement of the ship for each unit of time. */
 	private static final int SPEED = 2;
 	/** 함선이 바라보고 있는 뱡향 */
-	private static String Direction;
-	
+	private static String Direction = "UP";
 	/** Minimum time between shots. */
 	private Cooldown shootingCooldown;
 	/** Time spent inactive between hits. */
@@ -93,7 +92,7 @@ public class Ship extends Entity {
 		if (this.shootingCooldown.checkFinished()) {
 			this.shootingCooldown.reset();
 			bullets.add(BulletPool.getBullet(positionX + this.width / 2,
-					positionY, BULLET_SPEED, Direction));
+					positionY, BULLET_SPEED, Direction, "SHIP"));
 			return true;
 		}
 		return false;

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -22,7 +22,7 @@ public class Ship extends Entity {
 	/** Movement of the ship for each unit of time. */
 	private static final int SPEED = 2;
 	/** 함선이 바라보고 있는 뱡향 */
-	private static String Direction = "UP";
+	private static String direction = "UP";
 	/** Minimum time between shots. */
 	private Cooldown shootingCooldown;
 	/** Time spent inactive between hits. */
@@ -35,16 +35,16 @@ public class Ship extends Entity {
 	 *            Initial position of the ship in the X axis.
 	 * @param positionY
 	 *            Initial position of the ship in the Y axis.
-	 * @param Direction
+	 * @param direction
 	 * 			  함선의 초기 방향.
 	 */
-	public Ship(final int positionX, final int positionY, String Direction) {
+	public Ship(final int positionX, final int positionY, String direction) {
 		super(positionX, positionY, 13 * 2, 8 * 2, Color.GREEN);
 
 		this.spriteType = SpriteType.Ship;
 		this.shootingCooldown = Core.getCooldown(SHOOTING_INTERVAL);
 		this.destructionCooldown = Core.getCooldown(1000);
-		this.Direction = Direction;
+		this.direction = direction;
 	}
 
 	/**
@@ -52,7 +52,7 @@ public class Ship extends Entity {
 	 * reached.
 	 */
 	public final void moveRight() {
-		this.Direction = "RIGHT";
+		this.direction = "RIGHT";
 		this.positionX += SPEED;
 	}
 
@@ -61,7 +61,7 @@ public class Ship extends Entity {
 	 * reached.
 	 */
 	public final void moveLeft() {
-		this.Direction = "LEFT";
+		this.direction = "LEFT";
 		this.positionX -= SPEED;
 	}
 
@@ -69,7 +69,7 @@ public class Ship extends Entity {
 	 * Moves the ship speed units up, or until the top screen border is reached.
 	 */
 	public final void moveUp() {
-		this.Direction = "UP";
+		this.direction = "UP";
 		this.positionY -= SPEED;
 	}
 
@@ -77,7 +77,7 @@ public class Ship extends Entity {
 	 * Moves the ship speed units down, or until the bottom screen border is reached.
 	 */
 	public final void moveDown() {
-		this.Direction = "DOWN";
+		this.direction = "DOWN";
 		this.positionY += SPEED;
 	}
 
@@ -92,7 +92,7 @@ public class Ship extends Entity {
 		if (this.shootingCooldown.checkFinished()) {
 			this.shootingCooldown.reset();
 			bullets.add(BulletPool.getBullet(positionX + this.width / 2,
-					positionY, BULLET_SPEED, Direction, "SHIP"));
+					positionY, BULLET_SPEED, direction, "SHIP"));
 			return true;
 		}
 		return false;
@@ -139,7 +139,7 @@ public class Ship extends Entity {
 	 * @return 함선의 방향.
 	 */
 	public String getDirection() {
-		return Direction;
+		return direction;
 	}
 
 	/**

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -18,9 +18,11 @@ public class Ship extends Entity {
 	/** Time between shots. */
 	private static final int SHOOTING_INTERVAL = 750;
 	/** Speed of the bullets shot by the ship. */
-	private static final int BULLET_SPEED = -6;
+	private static final int BULLET_SPEED = 6;
 	/** Movement of the ship for each unit of time. */
 	private static final int SPEED = 2;
+	/** 함선이 바라보고 있는 뱡향 */
+	private static String Direction;
 	
 	/** Minimum time between shots. */
 	private Cooldown shootingCooldown;
@@ -34,13 +36,16 @@ public class Ship extends Entity {
 	 *            Initial position of the ship in the X axis.
 	 * @param positionY
 	 *            Initial position of the ship in the Y axis.
+	 * @param Direction
+	 * 			  함선의 초기 방향.
 	 */
-	public Ship(final int positionX, final int positionY) {
+	public Ship(final int positionX, final int positionY, String Direction) {
 		super(positionX, positionY, 13 * 2, 8 * 2, Color.GREEN);
 
 		this.spriteType = SpriteType.Ship;
 		this.shootingCooldown = Core.getCooldown(SHOOTING_INTERVAL);
 		this.destructionCooldown = Core.getCooldown(1000);
+		this.Direction = Direction;
 	}
 
 	/**
@@ -48,6 +53,7 @@ public class Ship extends Entity {
 	 * reached.
 	 */
 	public final void moveRight() {
+		this.Direction = "RIGHT";
 		this.positionX += SPEED;
 	}
 
@@ -56,6 +62,7 @@ public class Ship extends Entity {
 	 * reached.
 	 */
 	public final void moveLeft() {
+		this.Direction = "LEFT";
 		this.positionX -= SPEED;
 	}
 
@@ -63,6 +70,7 @@ public class Ship extends Entity {
 	 * Moves the ship speed units up, or until the top screen border is reached.
 	 */
 	public final void moveUp() {
+		this.Direction = "UP";
 		this.positionY -= SPEED;
 	}
 
@@ -70,6 +78,7 @@ public class Ship extends Entity {
 	 * Moves the ship speed units down, or until the bottom screen border is reached.
 	 */
 	public final void moveDown() {
+		this.Direction = "DOWN";
 		this.positionY += SPEED;
 	}
 
@@ -84,7 +93,7 @@ public class Ship extends Entity {
 		if (this.shootingCooldown.checkFinished()) {
 			this.shootingCooldown.reset();
 			bullets.add(BulletPool.getBullet(positionX + this.width / 2,
-					positionY, BULLET_SPEED));
+					positionY, BULLET_SPEED, Direction));
 			return true;
 		}
 		return false;
@@ -123,6 +132,15 @@ public class Ship extends Entity {
 	 */
 	public final int getSpeed() {
 		return SPEED;
+	}
+
+	/**
+	 * 함선의 방향을 얻는 Getter
+	 *
+	 * @return 함선의 방향.
+	 */
+	public String getDirection() {
+		return Direction;
 	}
 
 	/**

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -22,7 +22,7 @@ public class Ship extends Entity {
 	/** Movement of the ship for each unit of time. */
 	private static final int SPEED = 2;
 	/** 함선이 바라보고 있는 뱡향 */
-	private static String direction = "UP";
+	private static String direction;
 	/** Minimum time between shots. */
 	private Cooldown shootingCooldown;
 	/** Time spent inactive between hits. */

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -307,7 +307,7 @@ public class GameScreen extends Screen {
 	private void manageCollisions() {
 		Set<Bullet> recyclable = new HashSet<Bullet>();
 		for (Bullet bullet : this.bullets)
-			if (bullet.getSpeed() > 0) {
+			if (bullet.getClassify() == 1) {
 				if (checkCollision(bullet, this.ship) && !this.levelFinished) {
 					if (!this.ship.isDestroyed()) {
 						recyclable.add(bullet);

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -113,7 +113,7 @@ public class GameScreen extends Screen {
 	public final void initialize() {
 		super.initialize();
 
-		this.ship = new Ship(this.width / 2, this.height / 2);
+		this.ship = new Ship(this.width / 2, this.height / 2, "UP");
 		enemyShipSet = new EnemyShipSet(this.gameSettings, this.ship);
 		enemyShipSet.attach(this);
 


### PR DESCRIPTION
## 개요

- 함선 이동 방향 확장에 따른 공격 방향 상하좌우로 확장

## 작업사항

- 키 입력에 따라 함선이 이동할 때, 이동 방향을 함선이 바라보고 있는 방향으로 설정
- Bullet을 생성할 때 함선의 방향을 Bullet의 진행 방향으로 설정
- 내 함선이 쏜 총알은 `SHIP`, 적 함선이 쏜 총알은 `ENEMY` classify로 설정

## 변경로직

- `Ship`에 `direction` 속성 추가
- `Bullet`에 `direction`, `classify` 속성 추가
- 총알의 진영을 speed가 아닌 `classify`로 결정하도록 변경

## 참고사항

- 관련 이슈 번호: #CTRLS-9
