### PR TITLE
[CTRLS-17] 아이템 선택화면 및 레벨 클리어 시 화면 이동 구현 

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -8,11 +8,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import screen.GameScreen;
-import screen.HighScoreScreen;
-import screen.ScoreScreen;
-import screen.Screen;
-import screen.TitleScreen;
+import screen.*;
 
 /**
  * Implements core game logic.
@@ -143,8 +139,17 @@ public final class Core {
 					frame.setScreen(currentScreen);
 					LOGGER.info("Closing game screen.");
 
+					// 현재 플레이한 게임의 정보를 gameState에 저장
 					gameState = ((GameScreen) currentScreen).getGameState();
 
+					// 아이템 선택화면으로 이동
+					// 아직 HP가 남아있거나 방금 깬 레벨이 마지막 레벨이 아닌 경우
+					if (gameState.getLivesRemaining() > 0 && gameState.getLevel() + 1 <= NUM_LEVELS) {
+						LOGGER.info("Starting " + WIDTH + "X" + HEIGHT + " ItemSelectingScreen at " + FPS + " fps.");
+						currentScreen = new ItemSelectedScreen(gameState, width, height, FPS);
+						frame.setScreen(currentScreen);
+						LOGGER.info("Closing Item Selecting Screen.");
+					}
 					gameState = new GameState(gameState.getLevel() + 1,
 							gameState.getScore(),
 							gameState.getLivesRemaining(),

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -630,7 +630,7 @@ public final class DrawManager {
 		else
 			backBufferGraphics.setColor(Color.WHITE);
 		// 첫 아이템 그리기
-		drawItemBox((screen.getWidth() / 4) - 50, 250);
+		drawItemBox((screen.getWidth() / 4) - 50, screen.getHeight() / 3);
 		//drawItem(0, (screen.getWidth() / 4), 350)
 
 		// 두번째 아이템 선택여부
@@ -639,7 +639,7 @@ public final class DrawManager {
 		else
 			backBufferGraphics.setColor(Color.WHITE);
 		// 두 번째 아이템 그리기
-		drawItemBox((screen.getWidth() * 2 / 4) - 50, 250);
+		drawItemBox((screen.getWidth() * 2 / 4) - 50, screen.getHeight() / 3);
 		//drawItem(1, (screen.getWidth() * 2 / 4), 350)
 
 		// 세번째 아이템 선택여부
@@ -648,7 +648,7 @@ public final class DrawManager {
 		else
 			backBufferGraphics.setColor(Color.WHITE);
 		//세 번째 아이템 그리기
-		drawItemBox((screen.getWidth() * 3) / 4 - 50, 250);
+		drawItemBox((screen.getWidth() * 3) / 4 - 50, screen.getHeight() / 3);
 		//drawItem(2, (screen.getWidth() * 3 / 4), 350)
 
 	}

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -607,16 +607,20 @@ public final class DrawManager {
 	}
 
 	public void drawItemSelectingTitle(final Screen screen, final GameState gameState) {
-		String titleString = "Level " + gameState.getLevel() + " Clear!!";
-		String instructionsString =
-				"Choose your Item";
+		String titleString = "Level  " + gameState.getLevel() + "  Clear!!";
+		String instructionsString1 =
+				"Select your Item with A + D / arrows";
+		String instructionsString2 =
+				"Press spacebar If you done.";
 		// 아이템 선택 지시 문구 표시
 		backBufferGraphics.setColor(Color.GRAY);
-		drawCenteredRegularString(screen, instructionsString,
-				screen.getHeight() / 100);
+		drawCenteredRegularString(screen, instructionsString1,
+				100);
+		drawCenteredRegularString(screen, instructionsString2, screen.getHeight() - 50);
 		// 레벨 클리어 문구 표시
 		backBufferGraphics.setColor(Color.GREEN);
 		drawCenteredBigString(screen, titleString, 50);
+
 	}
 
 	public void drawSelectedItem(final Screen screen, final List<Integer> itemList, final int selectedItem) {
@@ -626,7 +630,7 @@ public final class DrawManager {
 		else
 			backBufferGraphics.setColor(Color.WHITE);
 		// 첫 아이템 그리기
-		drawItemBox((screen.getWidth() / 4) - 50, 300);
+		drawItemBox((screen.getWidth() / 4) - 50, 250);
 		//drawItem(0, (screen.getWidth() / 4), 350)
 
 		// 두번째 아이템 선택여부
@@ -635,7 +639,7 @@ public final class DrawManager {
 		else
 			backBufferGraphics.setColor(Color.WHITE);
 		// 두 번째 아이템 그리기
-		drawItemBox((screen.getWidth() * 2 / 4) - 50, 300);
+		drawItemBox((screen.getWidth() * 2 / 4) - 50, 250);
 		//drawItem(1, (screen.getWidth() * 2 / 4), 350)
 
 		// 세번째 아이템 선택여부
@@ -644,7 +648,7 @@ public final class DrawManager {
 		else
 			backBufferGraphics.setColor(Color.WHITE);
 		//세 번째 아이템 그리기
-		drawItemBox((screen.getWidth() * 3) / 4 - 50, 300);
+		drawItemBox((screen.getWidth() * 3) / 4 - 50, 250);
 		//drawItem(2, (screen.getWidth() * 3 / 4), 350)
 
 	}

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -601,4 +601,57 @@ public final class DrawManager {
 
 		backBufferGraphics.drawString(timeString, xPosition, yPosition);
 	}
+
+	public void drawItemBox(final int position_X, final int position_Y) {
+		backBufferGraphics.drawRect(position_X, position_Y, 100, 100);
+	}
+
+	public void drawItemSelectingTitle(final Screen screen, final GameState gameState) {
+		String titleString = "Level " + gameState.getLevel() + " Clear!!";
+		String instructionsString =
+				"Choose your Item";
+		// 아이템 선택 지시 문구 표시
+		backBufferGraphics.setColor(Color.GRAY);
+		drawCenteredRegularString(screen, instructionsString,
+				screen.getHeight() / 100);
+		// 레벨 클리어 문구 표시
+		backBufferGraphics.setColor(Color.GREEN);
+		drawCenteredBigString(screen, titleString, 50);
+	}
+
+	public void drawSelectedItem(final Screen screen, final List<Integer> itemList, final int selectedItem) {
+		// 첫 아이템 선택여부
+		if (selectedItem == 0)
+			backBufferGraphics.setColor(Color.GREEN);
+		else
+			backBufferGraphics.setColor(Color.WHITE);
+		// 첫 아이템 그리기
+		drawItemBox((screen.getWidth() / 4) - 50, 300);
+		//drawItem(0, (screen.getWidth() / 4), 350)
+
+		// 두번째 아이템 선택여부
+		if (selectedItem == 1)
+			backBufferGraphics.setColor(Color.GREEN);
+		else
+			backBufferGraphics.setColor(Color.WHITE);
+		// 두 번째 아이템 그리기
+		drawItemBox((screen.getWidth() * 2 / 4) - 50, 300);
+		//drawItem(1, (screen.getWidth() * 2 / 4), 350)
+
+		// 세번째 아이템 선택여부
+		if (selectedItem == 2)
+			backBufferGraphics.setColor(Color.GREEN);
+		else
+			backBufferGraphics.setColor(Color.WHITE);
+		//세 번째 아이템 그리기
+		drawItemBox((screen.getWidth() * 3) / 4 - 50, 300);
+		//drawItem(2, (screen.getWidth() * 3 / 4), 350)
+
+	}
+
+	// 각 아이템을 그리는 메소드
+	public void drawItem(final int item, final int position_X, final int position_Y){
+		// drawEntity로 해당 Item 스프라이트를 그림
+		// drawString 으로 해당 Item에 대한 설명 및 정보를 화면 아래 부분에 추가
+	}
 }

--- a/src/screen/ItemSelectedScreen.java
+++ b/src/screen/ItemSelectedScreen.java
@@ -1,0 +1,101 @@
+package screen;
+
+import engine.Cooldown;
+import engine.Core;
+import engine.GameState;
+
+import java.util.ArrayList;
+import java.awt.event.KeyEvent;
+import java.util.List;
+
+
+public class ItemSelectedScreen extends Screen {
+
+    // 화면 표시항 아이템셋 (3개)
+    List<Integer> itemList = new ArrayList<>();
+    // 선택 쿨다운
+    private Cooldown selectionCooldown;
+    // 선택 전환 가능 쿨타임
+    private static final int SELECTION_TIME = 200;
+    // 현재 선택된 아이템
+    private int selectedItem;
+    // 현재 게임 정보를 얻어오기 위한 게임 상태 변수
+    private GameState gameState;
+
+    // 생성자 - 아이템셋, width, height, fps 받아옴
+    public ItemSelectedScreen (final GameState gameState, final int width, final int height, final int fps) {
+        super(width, height, fps);
+
+        //아이템 리스트 - 예시용(1번, 2번, 3번 아이템)
+        itemList.add(1);
+        itemList.add(2);
+        itemList.add(3);
+
+        this.gameState = gameState;
+        this.selectionCooldown = Core.getCooldown(SELECTION_TIME);
+        this.selectionCooldown.reset();
+    }
+
+    // 화면 가동 메소드
+    public final int run() {
+        run();
+
+        return 0;
+    }
+    // 화면 업데이트 메소드
+    protected final void update() {
+        super.update();
+
+        draw();
+        if (this.selectionCooldown.checkFinished()
+                && this.inputDelay.checkFinished()) {
+            if (inputManager.isKeyDown(KeyEvent.VK_A)
+                    || inputManager.isKeyDown(KeyEvent.VK_LEFT)) {
+                previousMenuItem();
+                this.selectionCooldown.reset();
+            }
+            if (inputManager.isKeyDown(KeyEvent.VK_D)
+                    || inputManager.isKeyDown(KeyEvent.VK_RIGHT)) {
+                nextMenuItem();
+                this.selectionCooldown.reset();
+            }
+            if (inputManager.isKeyDown(KeyEvent.VK_SPACE))
+                // 해당 아이템 효과 적용 코드 추가
+                // Code Content...
+
+                this.isRunning = false;
+        }
+    }
+
+    /**
+     * Shifts the focus to the next menu item.
+     */
+    private void nextMenuItem() {
+        if (this.selectedItem == 2)
+            this.selectedItem = 0;
+        else
+            this.selectedItem++;
+    }
+
+    /**
+     * Shifts the focus to the previous menu item.
+     */
+    private void previousMenuItem() {
+        if (this.selectedItem == 0)
+            this.selectedItem = 2;
+        else
+            this.selectedItem--;
+    }
+
+
+    // 화면 draw 메소드
+    private void draw() {
+        drawManager.initDrawing(this);
+
+        drawManager.drawItemSelectingTitle(this, this.gameState);
+        drawManager.drawSelectedItem(this, itemList, this.selectedItem);
+
+        drawManager.completeDrawing(this);
+    }
+
+}

--- a/src/screen/ItemSelectedScreen.java
+++ b/src/screen/ItemSelectedScreen.java
@@ -38,7 +38,7 @@ public class ItemSelectedScreen extends Screen {
 
     // 화면 가동 메소드
     public final int run() {
-        run();
+        super.run();
 
         return 0;
     }


### PR DESCRIPTION
## 기능
 레벨 클리어 시에 아이템 선택화면으로 이동됩니다. 아이템 선택화면에서는 가장 위에 어떤 레벨을 클리어 했는지 출력되고 그 밑에 아이템을 A, D 혹은 방향키로 고르라고 지시문구가 출력됩니다. 그리고 아이템 박스로 3개가 표시되고 이후에 아이템이 추가되면 해당 박스 안에 아이템 스프라이트. 그리고 밑의 빈 부분에 해당 아이템의 효과, 현재 레벨 등의 정보를 표시할 생각입니다.
맨 밑에는 스페이스바를 눌러서 진행하라는 문구가 떠 있습니다. 

## 코드

### ItemSelectedScreen 클래스 
아이템 선택 화면에 대한 클래스 입니다. 
현재는 
이전에 클리어한 레벨을 알기 위한 GameState
화면의 기본 값(width, height, fps)를 받지만
이후에 무작위 선발된 3개의 아이템 리스트를 받아올 예정입니다. 

#### update() 메소드 
아직 추가되지는 않았지만, 스페이스바를 누르면 고른 아이템의 효과가 적용되도록 코드의 수정이 일부 필요합니다.

### DrawManager 클래스
아이템 선택화면을 그려내는 메소드들이 추가되었습니다.

drawItemBox와 drawItem은 아이템과 관련된 요소를 그리고 
drawSelectedItem은 고르는 아이템만 초록색으로 나머지는 흰색으로 표시합니다. 

이 방식은 Item 구현 방식에 따라서 약간의 변화가 있을 수 있습니다.

### Core 클래스
레벨이 클리어 되고 GamaState가 레벨 + 1로 갱신 되기 전에 아이템 선택화면으로 전환되도록 코드를 추가하였습니다. 
조건에 HP가 남아있거나 방금 클리어한 레벨이 마지막 레벨이 아니어야 함을 추가하여 죽거나 모두 클리어할 시에는 아이템 선택화면으로 이동되지 않도록 하였습니다. 

### 스크린샷
![{9A9E6B34-CB6B-45D3-9BBA-DDFDEC4EF278}](https://github.com/user-attachments/assets/b4b9e33a-0280-4d75-90d1-5451476a01c6)
실제 인게임 화면입니다. 선택한 아이템이 초록색으로 표시됩니다. 

### 추가의견 - 아이템 구현 방향성
Item 폴더를 만들어 각 ??Item에 대한 클래스를 만듭니다. 이때 각 ??Item은 Item 인터페이스를 따라서 만들어 집니다.
Item 인터페이스는 Item의 생성자, 효과를 적용시키는 메소드, 아이템 설명을 리턴해주는 메소드 등이 포합됩니다. 통일된 구조로 만들어진 Item들은 ItemSet클래스에서 Set에 한 개씩 들어가 있는 상태로 관리됩니다. ItemSet에서 무작위로 3개를 뽑아 ArrayList로 리턴해주는 ItemSelect 클래스를 만듭니다. 그리고 이를 이용하여 아이템 선택 화면과 연결시킵니다. 


우선 제가 생각한 방향은 이런 느낌인데 더 나은 의견 있으시면 말씀주시면 감사하겠습니다. 