### PR TITLE
[CTRLS-52] 이동 방향과 에임 방향 분리

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -234,7 +234,6 @@ public final class DrawManager {
                 break;
             case RIGHT:
             case UP_RIGHT:
-                Core.getLogger().info(entity.getSpriteType() + "UP_RIGHT 실행");
                 for (int i = 0; i < image.length; i++) {
                     for (int j = 0; j < image[i].length; j++) {
                         if (image[i][j]) {

--- a/src/entity/Entity.java
+++ b/src/entity/Entity.java
@@ -139,10 +139,20 @@ public class Entity {
         return this.height;
     }
 
+    /**
+     * 엔티티의 방향을 얻는 Getter. Ship의 경우 에임의 방향, Bullet의 경우 발사 방향.
+     *
+     * @return 엔티티의 방향.
+     */
     public Direction getDirection() {
         return this.direction;
     }
 
+    /**
+     * 엔티티의 방향을 설정하는 Setter. Ship의 경우 에임의 방향, Bullet의 경우 발사 방향.
+     *
+     * @param direction 설정할 엔티티의 방향.
+     */
     public void setDirection(final Direction direction) {
         this.direction = direction;
     }

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -23,7 +23,7 @@ public class Ship extends Entity {
     private int speed;
     /** 함선의 기본 데미지 */
     private int baseDamage;
-    /** 함선이 바라보고 있는 뱡향 */
+    /** 함선의 에임 뱡향 */
     private static Direction direction;
     /** 축 방향 속도의 소수 부분을 저장 및 누적 */
     private double remainingMovement = 0;
@@ -39,7 +39,7 @@ public class Ship extends Entity {
      *
      * @param positionX Initial position of the ship in the X axis.
      * @param positionY Initial position of the ship in the Y axis.
-     * @param direction 함선의 초기 방향.
+     * @param direction 함선의 초기 에임 방향.
      */
     public Ship(final int positionX, final int positionY, final Direction direction) {
         super(positionX, positionY, 13 * 2, 8 * 2, Color.GREEN, direction);
@@ -55,7 +55,6 @@ public class Ship extends Entity {
         this.shootingCooldown = Core.getCooldown(this.shootingInterval);
         this.destructionCooldown = Core.getCooldown(200);
 
-
         this.direction = direction;
     }
 
@@ -63,7 +62,6 @@ public class Ship extends Entity {
      * Moves the ship right until the right screen border is reached.
      */
     public final void moveRight() {
-        this.direction = Direction.RIGHT;
         this.positionX += speed;
     }
 
@@ -71,7 +69,6 @@ public class Ship extends Entity {
      * Moves the ship left until the left screen border is reached.
      */
     public final void moveLeft() {
-        this.direction = Direction.LEFT;
         this.positionX -= speed;
     }
 
@@ -79,7 +76,6 @@ public class Ship extends Entity {
      * Moves the ship up until the top screen border is reached.
      */
     public final void moveUp() {
-        this.direction = Direction.UP;
         this.positionY -= speed;
     }
 
@@ -87,7 +83,6 @@ public class Ship extends Entity {
      * Moves the ship down until the bottom screen border is reached.
      */
     public final void moveDown() {
-        this.direction = Direction.DOWN;
         this.positionY += speed;
     }
 
@@ -95,7 +90,6 @@ public class Ship extends Entity {
      * Moves the ship up the right until the top and right screen border is reached.
      */
     public final void moveUpRight() {
-        this.direction = Direction.UP_RIGHT;
         calculateMovement();
         this.positionY -= movement;
         this.positionX += movement;
@@ -105,7 +99,6 @@ public class Ship extends Entity {
      * Moves the ship up the left until the top and left screen border is reached.
      */
     public final void moveUpLeft() {
-        this.direction = Direction.UP_LEFT;
         calculateMovement();
         this.positionY -= movement;
         this.positionX -= movement;
@@ -115,7 +108,6 @@ public class Ship extends Entity {
      * Moves the ship down the right until the bottom and right screen border is reached.
      */
     public final void moveDownRight() {
-        this.direction = Direction.DOWN_RIGHT;
         calculateMovement();
         this.positionY += movement;
         this.positionX += movement;
@@ -125,7 +117,6 @@ public class Ship extends Entity {
      * Moves the ship down the left until the bottom and left screen border is reached.
      */
     public final void moveDownLeft() {
-        this.direction = Direction.DOWN_LEFT;
         calculateMovement();
         this.positionY += movement;
         this.positionX -= movement;
@@ -177,8 +168,6 @@ public class Ship extends Entity {
         }
     }
 
-
-
     /**
      * Switches the ship to its destroyed state.
      */
@@ -196,9 +185,9 @@ public class Ship extends Entity {
     }
 
     /**
-     * 함선이 대각선 방향을 바라보고 있는지 체크
+     * 함선의 에임이 대각선 방향인지 체크.
      *
-     * @return 함선의 방향이 대각선 방향이면 True
+     * @return 에임 방향이 대각선 방향이면 True.
      */
     public final boolean isDiagonal() {
         return switch (direction) {
@@ -221,9 +210,18 @@ public class Ship extends Entity {
     }
 
     /**
-     * 함선의 방향을 얻는 Getter
+     * 함선의 에임 방향을 설정하는 Setter.
      *
-     * @return 함선의 방향.
+     * @param direction 설정할 에임의 방향.
+     */
+    public final void setDirection(Direction direction) {
+        this.direction = direction;
+    }
+
+    /**
+     * 함선의 에임 방향을 얻는 Getter.
+     *
+     * @return 함선의 에임 방향.
      */
     public Direction getDirection() {
         return direction;

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -1,6 +1,7 @@
 package screen;
 
 import engine.DrawManager;
+import entity.Entity.Direction;
 import java.awt.event.KeyEvent;
 import java.util.HashSet;
 import java.util.Set;
@@ -23,7 +24,7 @@ public class GameScreen extends Screen {
     private static final int INPUT_DELAY = 6000;
     /** Bonus score for each life remaining at the end of the level. */
     private static final int LIFE_SCORE = 100;
-    /** 함선이 체력을 자동으로 회복하는 쿨타임. 기본값은 5000 밀리세컨드로 설정됨.*/
+    /** 함선이 체력을 자동으로 회복하는 쿨타임. 기본값은 5000 밀리세컨드로 설정됨. */
     private Cooldown hpRegenCooldown;
     /** Minimum time between bonus ship's appearances. */
     private static final int BONUS_SHIP_INTERVAL = 20000;
@@ -176,17 +177,18 @@ public class GameScreen extends Screen {
             this.levelStarted = true;
         }
 
-
         if (this.inputDelay.checkFinished() && !this.levelFinished) {
 
-            boolean moveRight = inputManager.isKeyDown(KeyEvent.VK_RIGHT)
-                || inputManager.isKeyDown(KeyEvent.VK_D);
-            boolean moveLeft = inputManager.isKeyDown(KeyEvent.VK_LEFT)
-                || inputManager.isKeyDown(KeyEvent.VK_A);
-            boolean moveUp = inputManager.isKeyDown(KeyEvent.VK_UP)
-                || inputManager.isKeyDown(KeyEvent.VK_W);
-            boolean moveDown = inputManager.isKeyDown(KeyEvent.VK_DOWN)
-                || inputManager.isKeyDown(KeyEvent.VK_S);
+            // WASD - 함선 이동
+            boolean moveRight = inputManager.isKeyDown(KeyEvent.VK_D);
+            boolean moveLeft = inputManager.isKeyDown(KeyEvent.VK_A);
+            boolean moveUp = inputManager.isKeyDown(KeyEvent.VK_W);
+            boolean moveDown = inputManager.isKeyDown(KeyEvent.VK_S);
+            // 방향키 - 에임
+            boolean aimRight = inputManager.isKeyDown(KeyEvent.VK_RIGHT);
+            boolean aimLeft = inputManager.isKeyDown(KeyEvent.VK_LEFT);
+            boolean aimUp = inputManager.isKeyDown(KeyEvent.VK_UP);
+            boolean aimDown = inputManager.isKeyDown(KeyEvent.VK_DOWN);
 
             boolean isRightBorder = this.ship.getPositionX()
                 + this.ship.getWidth() + this.ship.getSpeed() > this.width - 1;
@@ -214,10 +216,33 @@ public class GameScreen extends Screen {
             } else if (moveDown && !isBottomBorder) {
                 this.ship.moveDown();
             }
-            if (inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
+
+            if (aimUp && aimRight) {
+                this.ship.setDirection(Direction.UP_RIGHT);
+            } else if (aimUp && aimLeft) {
+                this.ship.setDirection(Direction.UP_LEFT);
+            } else if (aimDown && aimRight) {
+                this.ship.setDirection(Direction.DOWN_RIGHT);
+            } else if (aimDown && aimLeft) {
+                this.ship.setDirection(Direction.DOWN_LEFT);
+            } else if (aimUp) {
+                this.ship.setDirection(Direction.UP);
+            } else if (aimDown) {
+                this.ship.setDirection(Direction.DOWN);
+            } else if (aimRight) {
+                this.ship.setDirection(Direction.RIGHT);
+            } else if (aimLeft) {
+                this.ship.setDirection(Direction.LEFT);
+            }
+
+            if (aimUp || aimDown || aimRight || aimLeft) {
                 if (this.ship.shoot(this.bullets)) {
                     this.bulletsShot++;
                 }
+            }
+
+            if (inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
+                // 추후 궁극기 추가
             }
 
             // esc키를 눌렀을 때 일시정지 화면으로 전환
@@ -256,10 +281,8 @@ public class GameScreen extends Screen {
             //		this.logger.info("The special ship has escaped");
             //}
 
-
             // 5초마다 체력 1씩 회복
             hpRegen();
-
 
             this.ship.update();
             this.enemyShipSet.update();
@@ -288,7 +311,6 @@ public class GameScreen extends Screen {
         if (this.levelFinished && this.screenFinishedCooldown.checkFinished()) {
             this.isRunning = false;
         }
-
 
 
     }
@@ -442,7 +464,7 @@ public class GameScreen extends Screen {
         return distanceX < maxDistanceX && distanceY < maxDistanceY;
     }
 
-    /** hpRegenCooldown이 끝날 때마다 자동으로 체력을 회복함.*/
+    /** hpRegenCooldown이 끝날 때마다 자동으로 체력을 회복함. */
     private void hpRegen() {
         if (this.hpRegenCooldown.checkFinished() && this.hp < this.maxHp) {
             this.hp++;


### PR DESCRIPTION
## 개요

- 기존 함선의 이동 방향과 동일하게 총알을 발사하던 방식에서 에임의 방향을 분리해 이동 방향과 상관없이 원하는 방향으로 총알을 발사할 수 있음

## 변경사항
### GameScreen.java
- update() 메소드에서 move<방향>을 WASD로만 결정하고 방향키로 aim<방향>을 결정
- 이동 방향이 아닌 에임 방향에 맞게 함선의 스프라이트 방향 설정
- 방향키로 총알 발사 방향 설정과 동시에 해당 방향으로 총알 발사
- 스페이스는 추후 궁극기 발동 키로 설정 예정

### Ship.java
- 이제 move<방향>() 메소드에서 함선의 방향 설정하지 않도록 변경
- Entity에서 함선의 에임 방향을 설정하는 setDirection() 메소드 오버라이딩

## 참고사항

- 관련 이슈 번호: #CTRLS-52
