### PR TITLE
[#23] fix: 좌우 공격 총알 스프라이트 위치 조정

### DIFF
--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -141,7 +141,7 @@ public class Ship extends Entity {
         if (this.shootingCooldown.checkFinished()) {
             this.shootingCooldown.reset();
             bullets.add(BulletPool.getBullet(positionX + this.width / 2,
-                positionY, this.bulletSpeed, this.baseDamage, direction, "SHIP"));
+                positionY + this.width / 2, this.bulletSpeed, this.baseDamage, direction, "SHIP"));
             return true;
         }
         return false;


### PR DESCRIPTION
- Ship.shoot() 메소드에서 bullet 객체 생성 위치의 Y 좌표를 함선의 중앙으로 수정

- 관련 이슈 번호: #23 