### PR TITLE
[#21] fix: 게임 종료 경고 안내 문구 색상 변경

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -881,7 +881,7 @@ public final class DrawManager {
 
         backBufferGraphics.setColor(Color.RED);
         drawCenteredBigString(screen, titleString, screen.getHeight() / 3);
-        backBufferGraphics.setColor(Color.GRAY);
+        backBufferGraphics.setColor(Color.WHITE);
         drawCenteredRegularString(screen, instructionsString1,
             screen.getHeight() / 3 + fontRegularMetrics.getHeight() * 2);
         drawCenteredRegularString(screen, instructionsString2,


### PR DESCRIPTION
게임 종료 시 경고 안내 문구를 회색에서 흰색으로 변경

DrawManager.java
- setColor() 메소드에서 경고 안내문구 부분을 GRAY가 아닌 WHITE로 설정

- 관련 이슈 번호: #21 