### PR TITLE
#38 Stat 업그레이드 반영되지 않던 버그 수정

### DIFF
--- a/src/main/java/kr/ac/hanyang/entity/Ship.java
+++ b/src/main/java/kr/ac/hanyang/entity/Ship.java
@@ -283,4 +283,15 @@ public class Ship extends Entity {
                 throw new IllegalArgumentException("Invalid shipID: " + shipID);
         }
     }
+
+    /**
+     * Ship의 Stat을 StatusManager에서 업데이트.
+     */
+    public void updateStatsFromStatusManager() {
+        StatusManager statusManager = Core.getStatusManager();
+        this.shootingInterval = statusManager.getShootingInterval();
+        this.bulletSpeed = statusManager.getBulletSpeed();
+        this.baseDamage = statusManager.getBaseDamage();
+        this.speed = statusManager.getSpeed();
+    }
 }

--- a/src/main/java/kr/ac/hanyang/screen/GameScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/GameScreen.java
@@ -150,6 +150,9 @@ public class GameScreen extends Screen {
     public final void initialize() {
         super.initialize();
 
+        // 게임 시작 시 StatusManager의 status 객체를 res/status 의 값으로 초기화
+        getStatusManager().resetDefaultStatus();
+
         this.ship = Ship.createShipByID(this.shipID, this.width / 2, this.height / 2);
         enemyShipSet = new EnemyShipSet(this.gameSettings, this.level, this.ship);
         enemyShipSet.attach(this);
@@ -164,9 +167,6 @@ public class GameScreen extends Screen {
         this.screenFinishedCooldown = Core.getCooldown(SCREEN_CHANGE_INTERVAL);
         this.bullets = new HashSet<Bullet>();
         this.experiences = new HashSet<Experience>(); // 경험치 집합 초기화
-
-        // 게임 시작 시 StatusManager의 status 객체를 res/status 의 값으로 초기화
-        getStatusManager().resetDefaultStatus();
 
         // 게임 시작 시 초기 아이템 리스트 생성
         itemList = items.initializedItems();
@@ -520,6 +520,7 @@ public class GameScreen extends Screen {
                         // 늘어난 체력에 맞게 현재 체력의 비율 조정
                         this.hp = ((int) (getStatusManager().getMaxHp() * portionHp));
                     }
+                    this.ship.updateStatsFromStatusManager();
                 }
             }
         }


### PR DESCRIPTION
## 개요

- ItemSelectedScreen에서 선택한 아이템이 함선에 반영되지 않던 버그 수정

## 변경사항

- GameScreen에서 resetDefaultStatus를 Ship 객체 생성 이전에 호출
- Ship 객체의 stat을 업데이트하는 updateStatsFromStatusManager 메소드 추가
- ItemSelectedScreen이 종료된 후 updateStatsFromStatusManager를 호출하여 아이템 변경사항 반영

## 참고사항

- 관련 이슈 번호: close #38 
