### PR TITLE
[Bug-42] <refactor> 31레벨에서 레벨업 하면 게임 크래쉬되는 오류 해결 

### DIFF
--- a/src/main/java/kr/ac/hanyang/engine/DrawManager.java
+++ b/src/main/java/kr/ac/hanyang/engine/DrawManager.java
@@ -658,56 +658,63 @@ public final class DrawManager {
 
     public void drawSelectedItem(final Screen screen, final List<Item> itemList,
         final int selectedItem) {
-        if (itemList.size() < 3) {
-            String alarmString = "Only  " + itemList.size() + "  items left you can upgrade!!";
+        if (itemList.size() != 0) {
+            if (itemList.size() < 3) {
+                String alarmString = "Only  " + itemList.size() + "  items left you can upgrade!!";
+                drawCenteredRegularString(screen, alarmString,
+                    150);
+            }
+
+            // 첫 아이템 선택여부
+            if (selectedItem == 0) {
+                backBufferGraphics.setColor(Color.WHITE);
+                // 아이템 설명 출력
+                drawCenteredRegularString(screen, itemList.get(selectedItem).getItemDescription(),
+                    screen.getHeight() / 3 + 200);
+                drawCenteredBigString(screen, itemList.get(selectedItem).getItemEffectDescription(),
+                    screen.getHeight() / 3 + 300);
+                backBufferGraphics.setColor(Color.GREEN);
+            } else {
+                backBufferGraphics.setColor(Color.WHITE);
+            }
+            // 첫 아이템 그리기
+            drawItemBox((screen.getWidth() / 4) - 50, screen.getHeight() / 3);
+
+            // 두번째 아이템 선택여부
+            if (selectedItem == 1) {
+                backBufferGraphics.setColor(Color.WHITE);
+                // 아이템 설명 출력
+                drawCenteredRegularString(screen, itemList.get(selectedItem).getItemDescription(),
+                    screen.getHeight() / 3 + 200);
+                drawCenteredBigString(screen, itemList.get(selectedItem).getItemEffectDescription(),
+                    screen.getHeight() / 3 + 300);
+                backBufferGraphics.setColor(Color.GREEN);
+            } else {
+                backBufferGraphics.setColor(Color.WHITE);
+            }
+            // 두 번째 아이템 그리기
+            drawItemBox((screen.getWidth() * 2 / 4) - 50, screen.getHeight() / 3);
+
+            // 세번째 아이템 선택여부
+            if (selectedItem == 2) {
+                backBufferGraphics.setColor(Color.WHITE);
+                // 아이템 설명 출력
+                drawCenteredRegularString(screen, itemList.get(selectedItem).getItemDescription(),
+                    screen.getHeight() / 3 + 200);
+                drawCenteredBigString(screen, itemList.get(selectedItem).getItemEffectDescription(),
+                    screen.getHeight() / 3 + 300);
+                backBufferGraphics.setColor(Color.GREEN);
+            } else {
+                backBufferGraphics.setColor(Color.WHITE);
+            }
+            //세 번째 아이템 그리기
+            drawItemBox((screen.getWidth() * 3) / 4 - 50, screen.getHeight() / 3);
+        }
+        else {
+            String alarmString = "There are no items left";
             drawCenteredRegularString(screen, alarmString,
                 150);
         }
-
-        // 첫 아이템 선택여부
-        if (selectedItem == 0) {
-            backBufferGraphics.setColor(Color.WHITE);
-            // 아이템 설명 출력
-            drawCenteredRegularString(screen, itemList.get(selectedItem).getItemDescription(),
-                screen.getHeight() / 3 + 200);
-            drawCenteredBigString(screen, itemList.get(selectedItem).getItemEffectDescription(),
-                screen.getHeight() / 3 + 300);
-            backBufferGraphics.setColor(Color.GREEN);
-        } else {
-            backBufferGraphics.setColor(Color.WHITE);
-        }
-        // 첫 아이템 그리기
-        drawItemBox((screen.getWidth() / 4) - 50, screen.getHeight() / 3);
-
-        // 두번째 아이템 선택여부
-        if (selectedItem == 1) {
-            backBufferGraphics.setColor(Color.WHITE);
-            // 아이템 설명 출력
-            drawCenteredRegularString(screen, itemList.get(selectedItem).getItemDescription(),
-                screen.getHeight() / 3 + 200);
-            drawCenteredBigString(screen, itemList.get(selectedItem).getItemEffectDescription(),
-                screen.getHeight() / 3 + 300);
-            backBufferGraphics.setColor(Color.GREEN);
-        } else {
-            backBufferGraphics.setColor(Color.WHITE);
-        }
-        // 두 번째 아이템 그리기
-        drawItemBox((screen.getWidth() * 2 / 4) - 50, screen.getHeight() / 3);
-
-        // 세번째 아이템 선택여부
-        if (selectedItem == 2) {
-            backBufferGraphics.setColor(Color.WHITE);
-            // 아이템 설명 출력
-            drawCenteredRegularString(screen, itemList.get(selectedItem).getItemDescription(),
-                screen.getHeight() / 3 + 200);
-            drawCenteredBigString(screen, itemList.get(selectedItem).getItemEffectDescription(),
-                screen.getHeight() / 3 + 300);
-            backBufferGraphics.setColor(Color.GREEN);
-        } else {
-            backBufferGraphics.setColor(Color.WHITE);
-        }
-        //세 번째 아이템 그리기
-        drawItemBox((screen.getWidth() * 3) / 4 - 50, screen.getHeight() / 3);
     }
 
     // 각 아이템을 화면에 그리는 메소드

--- a/src/main/java/kr/ac/hanyang/screen/ItemSelectedScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/ItemSelectedScreen.java
@@ -63,10 +63,16 @@ public class ItemSelectedScreen extends Screen {
                 this.selectionCooldown.reset();
             }
             if (inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
-                // 해당 아이템 효과 적용
-                item_num = items.get(selectedItem).activateItem();
-                // 화면 종료
-                this.isRunning = false;
+                // items가 존재하는 경우에만 적용
+                if (items.size() != 0) {
+                    // 해당 아이템 효과 적용
+                    item_num = items.get(selectedItem).activateItem();
+                    // 화면 종료
+                    this.isRunning = false;
+                } //items에 아이템이 없으면 스페이스바 누르면 그냥 넘어가도록 지정
+                else {
+                    this.isRunning = false;
+                }
             }
         }
     }


### PR DESCRIPTION
- 아이템 선택화면으로 넘어갈때 items 배열에 아이템이 없는 경우를 예외형으로 처리하도록 if문을 추가하였습니다.

selectedItem 변수는 아이템이 없는 경우 0으로 고정되는데 해당 부분은 아이템의 설명을 불러오는 부분에서 오류가 생길수 있어서 drawSelectedItem 부분을 items 배열의 사이즈가 0인경우 아예 실행되지 않도록 바꾸었습니다.

아이템 Select 화면에서 스페이스바 입력시 원래 아이템을 적용하고 나가지는데, items가 없는 경우 null의 적용 메소드를 불러와서 크래쉬 되는 경우를 if 문을 추가하였습니다.

	modified:   src/main/java/kr/ac/hanyang/Item/ItemList.java
	modified:   src/main/java/kr/ac/hanyang/engine/DrawManager.java
	modified:   src/main/java/kr/ac/hanyang/screen/ItemSelectedScreen.java