### PR TITLE
[ENHANCEMENT] 경험치 소멸 효과, 색상 추가 #41

### DIFF
--- a/src/main/java/kr/ac/hanyang/entity/EnemyShip.java
+++ b/src/main/java/kr/ac/hanyang/entity/EnemyShip.java
@@ -20,7 +20,7 @@ public class EnemyShip extends Entity {
     /** Point value of a type A enemy. */
     private static final int A_TYPE_POINTS = 10;
     /** Point value of a type B enemy. */
-    private static final int B_TYPE_POINTS = 20;
+    private static final int B_TYPE_POINTS = 50;
     /** Point value of a type C enemy. */
     private static final int C_TYPE_POINTS = 30;
     /** Point value of a bonus enemy. */

--- a/src/main/java/kr/ac/hanyang/entity/Experience.java
+++ b/src/main/java/kr/ac/hanyang/entity/Experience.java
@@ -9,9 +9,10 @@ public class Experience extends Entity {
 
     // 지속시간
     private static final long DURATION = 10000; // 10초
+    private static final long WARNING_DURATION = 3000; // 소멸 경고 시간 3초
+    private static final Color[] WARNING_COLOR = new Color[]{Color.BLACK};
 
     private int value;
-    // 플레이어를 지속적으로 추적하는데 필요한 변수
     private double remainingMovementX = 0;
     private double remainingMovementY = 0;
     protected Cooldown animationCooldown;
@@ -19,9 +20,14 @@ public class Experience extends Entity {
     // 생성된 시간을 저장
     private long creationTime;
 
+    // 원래 색상과 경고 색상
+    private Color[] originalColor;
+    private boolean isWarningColor = false;
+
     public Experience(int positionX, int positionY, int value) {
         super(positionX, positionY, 7, 7, Color.GREEN);
         this.value = value;
+        this.originalColor = this.getColor();
 
         this.spriteType = SpriteType.ExperienceA;
 
@@ -45,6 +51,17 @@ public class Experience extends Entity {
             } else {
                 this.spriteType = SpriteType.ExperienceA;
             }
+
+            // 소멸 경고 시간인지 확인
+            if (System.currentTimeMillis() - creationTime > DURATION - WARNING_DURATION) {
+                // 색상 교체
+                if (isWarningColor) {
+                    this.setColor(originalColor, false);
+                } else {
+                    this.setColor(WARNING_COLOR, false);
+                }
+                isWarningColor = !isWarningColor;
+            }
         }
     }
 
@@ -54,7 +71,6 @@ public class Experience extends Entity {
      * @param distanceX Distance to move in the X axis.
      * @param distanceY Distance to move in the Y axis.
      */
-    // 이동 잔량을 남기어 최소 단위인 1 이상만큼이 누적되면 누적된 정수만큼 이동후 이동 잔량에서 뺄셈.
     public final void move(final double distanceX, final double distanceY) {
         this.remainingMovementX += distanceX;
         this.remainingMovementY += distanceY;
@@ -79,6 +95,13 @@ public class Experience extends Entity {
 
     public void setCreationTime(long creationTime) {
         this.creationTime = creationTime;
+    }
+
+    public void setColor(Color[] color, boolean updateOriginal) {
+        super.setColor(color);
+        if (updateOriginal) {
+            this.originalColor = color;
+        }
     }
 
     public boolean isExpired() {

--- a/src/main/java/kr/ac/hanyang/entity/Experience.java
+++ b/src/main/java/kr/ac/hanyang/entity/Experience.java
@@ -7,11 +7,17 @@ import kr.ac.hanyang.engine.DrawManager.SpriteType;
 
 public class Experience extends Entity {
 
+    // 지속시간
+    private static final long DURATION = 10000; // 10초
+
     private int value;
     // 플레이어를 지속적으로 추적하는데 필요한 변수
     private double remainingMovementX = 0;
     private double remainingMovementY = 0;
     protected Cooldown animationCooldown;
+
+    // 생성된 시간을 저장
+    private long creationTime;
 
     public Experience(int positionX, int positionY, int value) {
         super(positionX, positionY, 7, 7, Color.GREEN);
@@ -21,6 +27,9 @@ public class Experience extends Entity {
 
         this.animationCooldown = Core.getCooldown(500);
         this.animationCooldown.reset();
+
+        // 생성된 시간 기록
+        this.creationTime = System.currentTimeMillis();
     }
 
     /**
@@ -66,5 +75,13 @@ public class Experience extends Entity {
 
     public void setValue(int value) {
         this.value = value;
+    }
+
+    public void setCreationTime(long creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    public boolean isExpired() {
+        return System.currentTimeMillis() - creationTime > DURATION; // 10초
     }
 }

--- a/src/main/java/kr/ac/hanyang/entity/ExperiencePool.java
+++ b/src/main/java/kr/ac/hanyang/entity/ExperiencePool.java
@@ -43,20 +43,22 @@ public final class ExperiencePool {
             experience.setPositionX(positionX);
             experience.setPositionY(positionY);
             experience.setValue(value);
+            experience.setCreationTime(System.currentTimeMillis());
         } else {
             experience = new Experience(positionX, positionY, value);
         }
         switch (value) {
             case A_TYPE_POINTS:
-                experience.setColor(new Color[] {Color.GREEN});
+                experience.setColor(new Color[]{Color.GREEN});
                 break;
             case B_TYPE_POINTS:
-                experience.setColor(new Color[] {Color.MAGENTA});
+                experience.setColor(new Color[]{Color.MAGENTA});
                 break;
             case C_TYPE_POINTS:
-                experience.setColor(new Color[] {Color.RED});
+                experience.setColor(new Color[]{Color.RED});
                 break;
-            default: experience.setColor(new Color[] {Color.GREEN});
+            default:
+                experience.setColor(new Color[]{Color.GREEN});
         }
         return experience;
     }

--- a/src/main/java/kr/ac/hanyang/entity/ExperiencePool.java
+++ b/src/main/java/kr/ac/hanyang/entity/ExperiencePool.java
@@ -1,6 +1,7 @@
 // src/entity/ExperiencePool.java
 package kr.ac.hanyang.entity;
 
+import java.awt.Color;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -8,6 +9,13 @@ import java.util.Set;
  * Implements a pool of recyclable experience points.
  */
 public final class ExperiencePool {
+
+    /** Point value of a type A enemy. */
+    private static final int A_TYPE_POINTS = 10;
+    /** Point value of a type B enemy. */
+    private static final int B_TYPE_POINTS = 50;
+    /** Point value of a type C enemy. */
+    private static final int C_TYPE_POINTS = 30;
 
     /** Set of already created experience points. */
     private static Set<Experience> pool = new HashSet<>();
@@ -37,6 +45,18 @@ public final class ExperiencePool {
             experience.setValue(value);
         } else {
             experience = new Experience(positionX, positionY, value);
+        }
+        switch (value) {
+            case A_TYPE_POINTS:
+                experience.setColor(new Color[] {Color.GREEN});
+                break;
+            case B_TYPE_POINTS:
+                experience.setColor(new Color[] {Color.MAGENTA});
+                break;
+            case C_TYPE_POINTS:
+                experience.setColor(new Color[] {Color.RED});
+                break;
+            default: experience.setColor(new Color[] {Color.GREEN});
         }
         return experience;
     }

--- a/src/main/java/kr/ac/hanyang/entity/ExperiencePool.java
+++ b/src/main/java/kr/ac/hanyang/entity/ExperiencePool.java
@@ -47,19 +47,21 @@ public final class ExperiencePool {
         } else {
             experience = new Experience(positionX, positionY, value);
         }
+        Color[] color;
         switch (value) {
             case A_TYPE_POINTS:
-                experience.setColor(new Color[]{Color.GREEN});
+                color = new Color[]{Color.GREEN};
                 break;
             case B_TYPE_POINTS:
-                experience.setColor(new Color[]{Color.MAGENTA});
+                color = new Color[]{Color.MAGENTA};
                 break;
             case C_TYPE_POINTS:
-                experience.setColor(new Color[]{Color.RED});
+                color = new Color[]{Color.RED};
                 break;
             default:
-                experience.setColor(new Color[]{Color.GREEN});
+                color = new Color[]{Color.GREEN};
         }
+        experience.setColor(color, true); // 색상 설정 및 원래 색상 업데이트
         return experience;
     }
 

--- a/src/main/java/kr/ac/hanyang/screen/GameScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/GameScreen.java
@@ -633,6 +633,11 @@ public class GameScreen extends Screen {
                     this.ship.updateStatsFromStatusManager();
                 }
             }
+
+            // 경험치 지속간 만료되면 경험치 제거
+            if (experience.isExpired()) {
+                collectedExperiences.add(experience);
+            }
         }
 
         // 충돌한 경험치 제거 및 반환


### PR DESCRIPTION
## 개요

- 경험치의 자동 소멸 기능 추가 및 소멸 경고 메커니즘 구현
- 적 유형별 포인트 값 조정 및 경험치 값에 따른 색상 업데이트
- 전반적인 게임 플레이 경험 개선

---

## 변경사항

### 경험치(`Experience`) 기능 개선
- **소멸 및 경고 지속시간 추가**  
  - 경험치 소멸을 위한 지속시간(`DURATION`)과 소멸 경고 시간(`WARNING_DURATION`) 상수를 추가하였습니다.  
  - 생성 시간 추적 및 소멸 여부를 확인하는 메서드 구현.  
  - 소멸 경고 시간 동안 색상이 기존 색상과 검정색으로 번갈아 변경되도록 애니메이션 적용.  
  [[관련 코드]](diffhunk://#diff-ae1a6206834fea9aea99ddeb5e0e02c26a6fa31ff358162751e5764ea115baefR10-R38)  
  [[관련 코드]](diffhunk://#diff-ae1a6206834fea9aea99ddeb5e0e02c26a6fa31ff358162751e5764ea115baefR54-R64)  
  [[관련 코드]](diffhunk://#diff-ae1a6206834fea9aea99ddeb5e0e02c26a6fa31ff358162751e5764ea115baefR95-R109)

### 게임플레이 개선 사항
- **적 유형별 점수 조정**  
  - **B 유형 적**의 점수 값을 기존 20점에서 **50점**으로 변경.  
  [[관련 코드]](diffhunk://#diff-7150ec9456552dbd5f644eb2756b442fc1426a094f1396a3ddeae657a8154283L23-R23)  

- **경험치(`ExperiencePool`) 색상 및 포인트 값 관리 추가**  
  - 적 유형에 따라 경험치 값(`A_TYPE_POINTS`, `B_TYPE_POINTS`, `C_TYPE_POINTS`)을 관리하기 위한 상수 추가.  
  - 경험치 생성 시 생성 시간을 기록하며, 값에 따라 색상(초록색, 자주색, 빨간색)을 설정.  
  [[관련 코드]](diffhunk://#diff-542be055f4ffb8e097f05b6d1d04a1f0f084db29e9af428fb392f6c44824ba96R4)  
  [[관련 코드]](diffhunk://#diff-542be055f4ffb8e097f05b6d1d04a1f0f084db29e9af428fb392f6c44824ba96R13-R19)  
  [[관련 코드]](diffhunk://#diff-542be055f4ffb8e097f05b6d1d04a1f0f084db29e9af428fb392f6c44824ba96R46-R64)  

- **소멸된 경험치 제거 추가**  
  - 게임 화면(`GameScreen`)에서 매 프레임마다 소멸된 경험치를 제거하도록 기능 추가.  
  [[관련 코드]](diffhunk://#diff-70e9acea037ec1b8743eb01f71e928c1138ab6134411bc33dc80a1cd05d341b2R636-R640)  

---

## 참고사항
- 해당 변경사항은 **`EnemyShip`**, **`Experience`**, **`ExperiencePool`**, **`GameScreen`** 클래스에 적용되었습니다.  
- 게임플레이의 난이도를 조정하고 사용자 경험을 개선하는 것을 목적으로 합니다.

<img width="832" alt="스크린샷 2024-12-02 21 39 17" src="https://github.com/user-attachments/assets/61ea2923-343d-4584-8750-f75afa32e5b2">

관련 이슈 번호: Close #41 