### PR TITLE
레벨업 기준치 증가 기능 추가

### DIFF
--- a/src/main/java/kr/ac/hanyang/screen/GameScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/GameScreen.java
@@ -42,8 +42,8 @@ public class GameScreen extends Screen {
     private static final int SCREEN_CHANGE_INTERVAL = 1500;
     /** Height of the interface separation line. */
     private static final int SEPARATION_LINE_HEIGHT = 40;
-    /** 아이템 선택 화면으로 넘어가는 경험치 기준 양 */
-    private static final int EXPERIENCE_THRESHOLD = 100;
+    /** 레벨업 기준량 증가량 */
+    public static final int EXPERIENCE_THRESHOLD_INTERVAL = 20;
     /** 기본 적 생성 간격 */
     private static final int ENEMY_SPAWN_INTERVAL = 2000;
 
@@ -108,6 +108,8 @@ public class GameScreen extends Screen {
     private static ItemList items = new ItemList();
     // 아이템 리스트 참조하기 위한 배열
     private static List<Item> itemList;
+    /** 아이템 선택 화면으로 넘어가는 경험치 기준 양 */
+    private int experienceThreshold = 100;
 
     /**
      * Constructor, establishes the properties of the screen.
@@ -463,7 +465,7 @@ public class GameScreen extends Screen {
         drawManager.drawLevel(this, this.playerLevel); // 현재 레벨 그리기
         drawManager.drawHorizontalLine(this, this.height - EXPERIENCE_BAR_HEIGHT - 1);
         drawManager.drawExperienceBar(this, this.currentExperience,
-            EXPERIENCE_THRESHOLD, EXPERIENCE_BAR_HEIGHT); // 경험치 바 그리기
+            experienceThreshold, EXPERIENCE_BAR_HEIGHT); // 경험치 바 그리기
         drawManager.drawUltGauge(this, this.ship); // 궁극기 게이지 그리기
 
         // Countdown to game start.
@@ -601,11 +603,12 @@ public class GameScreen extends Screen {
                 Core.getSoundManager().playExpCollectSound();
 
                 // 임계점 도달 시 레벨 증가
-                while (currentExperience >= EXPERIENCE_THRESHOLD) {
+                while (currentExperience >= experienceThreshold) {
                     playerLevel++;
                     this.logger.info("플레이어 레벨 업! 현재 레벨: " + playerLevel);
                     Core.getSoundManager().playLevelUpSound();
-                    currentExperience -= EXPERIENCE_THRESHOLD;
+                    currentExperience -= experienceThreshold;
+                    experienceThreshold += EXPERIENCE_THRESHOLD_INTERVAL; // 레벨업 기준 경험치 증가
                     // 선택한 아이템 없는 것으로 초기화
                     int selectedItem = -1;
                     this.logger.info(


### PR DESCRIPTION
## 개요

- `GameScreen` 클래스에서 레벨업을 위한 경험치 기준 양을 동적으로 처리하도록 수정되었습니다. 이번 변경은 레벨업 시 경험치 기준이 증가하는 기능을 추가합니다.

## 변경사항

- `EXPERIENCE_THRESHOLD`를 정적 변수에서 인스턴스 변수로 변경하여 초기값을 100으로 설정.
- 새로운 상수 `EXPERIENCE_THRESHOLD_INTERVAL`을 추가하여 레벨업 시 경험치 기준 증가값을 20으로 설정.
- `draw()` 메서드에서 경험치 바를 그릴 때 인스턴스 변수 `experienceThreshold`를 사용하도록 수정.
- 플레이어가 레벨업할 때마다 `experienceThreshold`를 `EXPERIENCE_THRESHOLD_INTERVAL`만큼 증가시키도록 변경.

## 참고사항

- 현재 경험치 증가량은 20입니다. 추후 밸런스 패치때는 `EXPERIENCE_THRESHOLD_INTERVAL` 상수 값만 조정하면 됩니다.