### PR TITLE
[ENHANCEMENT] 궁극기 효과 남은 시간 표시

### DIFF
--- a/src/main/java/kr/ac/hanyang/engine/Cooldown.java
+++ b/src/main/java/kr/ac/hanyang/engine/Cooldown.java
@@ -100,6 +100,22 @@ public class Cooldown {
         }
     }
 
+    public final int getMilliseconds() {
+        return this.milliseconds;
+    }
+
+    public final int getRemainingTime() {
+        if (isPaused) {
+            return this.remainingTime;
+        } else if (this.time == 0) {
+            return this.milliseconds;
+        } else {
+            long currentTime = System.currentTimeMillis();
+            int timeLeft = (int) ((this.time + this.duration) - currentTime);
+            return Math.max(timeLeft, 0);
+        }
+    }
+
     /**
      * 쿨다운이 멈춰있는지 체크.
      *

--- a/src/main/java/kr/ac/hanyang/engine/DrawManager.java
+++ b/src/main/java/kr/ac/hanyang/engine/DrawManager.java
@@ -1215,6 +1215,21 @@ public final class DrawManager {
         backBufferGraphics.drawString(hpText, textX, textY);
     }
 
+    public void drawUltRemainingTime(final Cooldown cooldown, final Ship ship) {
+        int barX = 10; // 궁극기 시간 바의 X 좌표
+        int barY = 53; // 궁극기 시간 바의 Y 좌표
+        int barWidth = 680; // 궁극기 시간 바의 최대 너비
+        int barHeight = 5; // 궁극기 시간 바의 높이
+
+        // 현재 남은 시간에 따른 바의 너비 계산
+        int timeWidth = (int) ((double) cooldown.getRemainingTime() / cooldown.getMilliseconds()
+            * barWidth);
+
+        // 체력 바 채우기
+        backBufferGraphics.setColor(ship.getColor()[0]); // 궁극기 시간 바의 색상
+        backBufferGraphics.fillRect(barX, barY, timeWidth, barHeight);
+    }
+
     // 미사일 폭발 반경 표시
     public void drawExplosionRadius(Missile missile) {
         backBufferGraphics.setColor(new Color(255, 69, 0, 128)); // 반투명 주황색

--- a/src/main/java/kr/ac/hanyang/screen/BossScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/BossScreen.java
@@ -723,10 +723,10 @@ public class BossScreen extends Screen {
             draw();
         }
 
-        if ((this.hp <= 0) && !this.phaseFinished) {
-            this.phaseFinished = true;
-            this.screenFinishedCooldown.reset();
-        }
+//        if ((this.hp <= 0) && !this.phaseFinished) {
+//            this.phaseFinished = true;
+//            this.screenFinishedCooldown.reset();
+//        }
 
         if (this.phaseFinished && this.screenFinishedCooldown.checkFinished()) {
             this.isRunning = false;
@@ -768,6 +768,10 @@ public class BossScreen extends Screen {
 
             // 보스의 체력바 그리기
             drawManager.drawBossHp(this, boss.getCurrentHp(), this.boss);
+            if (this.ship.isUltActivated()) {
+                // 궁극기 남은 시간 그리기
+                drawManager.drawUltRemainingTime(this.ultActivatedTime, this.ship);
+            }
             // 아군 함선의 체력바 그리기
             drawManager.drawLives(10, this.getHeight() - 30, this.hp);
             // 아군 함선의 궁극기바 그리기

--- a/src/main/java/kr/ac/hanyang/screen/BossScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/BossScreen.java
@@ -723,10 +723,10 @@ public class BossScreen extends Screen {
             draw();
         }
 
-//        if ((this.hp <= 0) && !this.phaseFinished) {
-//            this.phaseFinished = true;
-//            this.screenFinishedCooldown.reset();
-//        }
+        if ((this.hp <= 0) && !this.phaseFinished) {
+            this.phaseFinished = true;
+            this.screenFinishedCooldown.reset();
+        }
 
         if (this.phaseFinished && this.screenFinishedCooldown.checkFinished()) {
             this.isRunning = false;


### PR DESCRIPTION
## 개요

- 현재 함선 궁극기 발동 시 스킬 효과는 적용 되지만 남은 시간이 얼마인지 시각적으로 확인 하기 어려움.

## 변경사항
### BossScreen.java
- 궁극기 사용 시 화면에 바 형태로 효과 지속시간이 지나면 바가 줄어들며 얼만큼 남았는지 표시.
### DrawManager.java
- 궁극기 남은 시간에 따라 바 형태로 그리는 `drawUltRemainingTime()` 메소드 추가
### Cooldown.java
- 설정된 쿨다운 ms를 반환하는 `getMilliseconds()` 메소드 추가
- 쿨다운이 시작했을 때 남은 시간은 반환하는 `getRemainingTime()` 메소드 추가

## 참고사항

- 관련 이슈 번호: #57 
