### PR TITLE
[BUG_FIX] 의도치 않은 상황에서 궁극기 게이지 증가 방지

### DIFF
--- a/src/main/java/kr/ac/hanyang/screen/BossScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/BossScreen.java
@@ -810,8 +810,8 @@ public class BossScreen extends Screen {
                 // 보스와의 충돌
                 if (checkCollision(bullet, this.boss) && this.boss.getCurrentHp() > 0) {
                     recyclable.add(bullet);
-                    this.ship.increaseUltGauge();
                     if (!this.boss.isInvincible()) {
+                        this.ship.increaseUltGauge();
                         this.boss.getDamaged(status.getBaseDamage());
                     }
                 }

--- a/src/main/java/kr/ac/hanyang/screen/GameScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/GameScreen.java
@@ -376,7 +376,9 @@ public class GameScreen extends Screen {
 
             // hp 자동 재생 기능 실행
             hpRegen(status.getRegenHp());
-            increaseUltGauge();
+            if (!this.isClear) {
+                increaseUltGauge();
+            }
 
             this.ship.update();
 


### PR DESCRIPTION
## 개요

- 일반 스테이지에서 300초에 도달했는데도 궁극기 게이지가 계속 상승하는 현상 발견.
- 보스 스테이지에서 보스가 무적 상태임에도 총알로 명중시 궁극기 게이지가 상승하는 현상 발견.

## 변경사항

- 포탈로 들어가기 전에 남은 궁극기를 모두 채우고 악용 방지를 위해 일반 스테이지 클리어시 궁극기 상승 중지.
- 무적일땐 명중에도 궁극기가 차지 않도록 변경.

## 참고사항

- 관련 이슈 번호: #59 
