### PR TITLE
[BUG_FIX] 보스 스테이지 진입 시 궁극기 종료

### DIFF
--- a/src/main/java/kr/ac/hanyang/screen/BossScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/BossScreen.java
@@ -151,6 +151,7 @@ public class BossScreen extends Screen {
         this.increUltCooldown = Core.getCooldown(1000);
         this.increUltCooldown.reset();
 
+        this.ship.stopUlt();
         // 아군 함선 궁극기 기능 연결
         switch (this.ship.getShipID()) {
             case 1:


### PR DESCRIPTION
## 개요

- 궁극기가 켜진 상태에서 포탈을 타고 보스 스테이지로 넘어가면 궁극기가 켜진 상태에서 보스 스테이지를 시작하는 버그

## 변경사항

- 보스 스테이지로 전환 시 궁극기는 꺼진 상태로 시작

## 참고사항

- 관련 이슈 번호: #62 
