### PR TITLE
[BUG_FIX] 쿨다운 일시정지 후 주기 짧아짐 버그 수정

### DIFF
--- a/src/main/java/kr/ac/hanyang/engine/Cooldown.java
+++ b/src/main/java/kr/ac/hanyang/engine/Cooldown.java
@@ -71,10 +71,13 @@ public class Cooldown {
     public final void reset() {
         this.time = System.currentTimeMillis();
         this.isPaused = false;
+        this.remainingTime = 0;
         if (this.variance != 0) {
             this.duration = (this.milliseconds - this.variance)
                 + (int) (Math.random()
                 * (this.variance + this.variance));
+        } else {
+            this.duration = this.milliseconds;
         }
     }
 


### PR DESCRIPTION
## 개요

- 쿨다운이 돌아가는 중에 pause()로 일시정지되고 resume()으로 다시 재개할 때, 다음 쿨다운 시간이 초기 설정된 시간이 아닌 이전 쿨다운 주기에서 resume()시 남은 시간만큼만 설정되는 버그 발생.

## 변경사항

- 쿨다운이 끝나고 reset하는 과정에서 duration을 초기 설정 값으로 초기화 하는 과정 추가.

## 참고사항

- 관련 이슈 번호: #64 
