### PR TITLE
[BUG_FIX] 스크린 전환 시 해당 스크린의 쿨다운 일시정지

### DIFF
--- a/src/main/java/kr/ac/hanyang/screen/BossScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/BossScreen.java
@@ -333,13 +333,9 @@ public class BossScreen extends Screen {
                 this.logger.info("Starting " + this.getWidth() + "x" + this.getHeight()
                     + " pause screen at " + this.fps + " fps.");
                 Screen pause = new PauseScreen(this.getWidth(), this.getHeight(), this.fps);
-                if (this.ship.isUltActivated()) {
-                    this.ultActivatedTime.pause();
-                }
+                pauseAllCooldown();
                 int check = pause.run();
-                if (this.ultActivatedTime.isPaused()) {
-                    this.ultActivatedTime.resume();
-                }
+                resumeAllCooldown();
                 this.logger.info("Closing pause screen.");
                 // 일시정지 화면에서 quit를 누른 경우 현재 라운드 종료
                 if (check == 2) {
@@ -1009,5 +1005,29 @@ public class BossScreen extends Screen {
     public void destroyAllAmmo() {
         this.bullets.clear();
         this.missiles.clear();
+    }
+
+    private void pauseAllCooldown() {
+        this.screenFinishedCooldown.pause();
+        this.clockCooldown.pause();
+        this.regenHpCooldown.pause();
+        this.increUltCooldown.pause();
+        this.ultActivatedTime.pause();
+        this.bossBasicBullet.pause();
+        this.createLaserCooldown.pause();
+        this.createMissileCooldown.pause();
+        this.createCrystalCooldown.pause();
+    }
+
+    private void resumeAllCooldown() {
+        this.screenFinishedCooldown.resume();
+        this.clockCooldown.resume();
+        this.regenHpCooldown.resume();
+        this.increUltCooldown.resume();
+        this.ultActivatedTime.resume();
+        this.bossBasicBullet.resume();
+        this.createLaserCooldown.resume();
+        this.createMissileCooldown.resume();
+        this.createCrystalCooldown.resume();
     }
 }

--- a/src/main/java/kr/ac/hanyang/screen/GameScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/GameScreen.java
@@ -350,13 +350,9 @@ public class GameScreen extends Screen {
                 this.logger.info("Starting " + this.getWidth() + "x" + this.getHeight()
                     + " pause screen at " + this.fps + " fps.");
                 Screen pause = new PauseScreen(this.getWidth(), this.getHeight(), this.fps);
-                if (this.ship.isUltActivated()) {
-                    this.ultActivatedTime.pause();
-                }
+                pauseAllCooldown();
                 int check = pause.run();
-                if (this.ultActivatedTime.isPaused()) {
-                    this.ultActivatedTime.resume();
-                }
+                resumeAllCooldown();
                 this.logger.info("Closing pause screen.");
                 // 일시정지 화면에서 quit를 누른 경우 현재 라운드 종료
                 if (check == 2) {
@@ -635,13 +631,9 @@ public class GameScreen extends Screen {
                             + this.fps + " fps.");
                     ItemSelectedScreen currentScreen = new ItemSelectedScreen(
                         items.getSelectedItemList(), width, height, this.fps, playerLevel);
-                    if (this.ship.isUltActivated()) {
-                        this.ultActivatedTime.pause();
-                    }
+                    pauseAllCooldown();
                     selectedItem = currentScreen.run();
-                    if (this.ultActivatedTime.isPaused()) {
-                        this.ultActivatedTime.resume();
-                    }
+                    resumeAllCooldown();
                     this.logger.info("Closing Item Selecting Screen.");
                     // 최대 체력 증가 아이템을 선택한 경우, 현재 체력 또한 증가된 체력만큼 올려줌.
                     if (selectedItem == 1) {
@@ -724,6 +716,22 @@ public class GameScreen extends Screen {
             this.ship.increaseUltGauge();
             this.increUltCooldown.reset();
         }
+    }
+
+    private void pauseAllCooldown() {
+        this.screenFinishedCooldown.pause();
+        this.clockCooldown.pause();
+        this.regenHpCooldown.pause();
+        this.increUltCooldown.pause();
+        this.ultActivatedTime.pause();
+    }
+
+    private void resumeAllCooldown() {
+        this.screenFinishedCooldown.resume();
+        this.clockCooldown.resume();
+        this.regenHpCooldown.resume();
+        this.increUltCooldown.resume();
+        this.ultActivatedTime.resume();
     }
 
     /**


### PR DESCRIPTION
## 개요

- 현재 게임 중 스크린 전환 시 궁극기 사용 시간에 대한 쿨다운만 일시정지/재개가 되고있음. 

## 변경사항

- 게임 스크린, 보스 스크린에서 관리하는 다른 모든 쿨다운도 동일한 방식 적용.

## 참고사항

- 관련 이슈 번호: #67 
