### PR TITLE
[BUG_FIX] 스크린 전환 쿨다운 리셋

### DIFF
--- a/src/main/java/kr/ac/hanyang/screen/GameScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/GameScreen.java
@@ -615,6 +615,7 @@ public class GameScreen extends Screen {
                 if (inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
                     this.returnCode = 2;
                     this.levelFinished = true;
+                    this.screenFinishedCooldown.reset();
                 }
             }
         }


### PR DESCRIPTION
## 개요

- 일반 스테이지에서 아이템 선택 화면이나 일시정지 화면을 한번 갔다와서 포탈 타고 보스 스테이지 넘어가려고 할 때, 스크린 전환 쿨다운이 끝나지 않은 것으로 판단돼 동작이 멈춤

## 변경사항

- 포탈에 입장하면 스크린 전환 쿨다운 리셋을 해줌

## 참고사항

- 관련 이슈 번호: #74 
