### PR TITLE
[BUG_FIX] 체력 바 크기 오류 수정

### DIFF
--- a/src/main/java/kr/ac/hanyang/engine/DrawManager.java
+++ b/src/main/java/kr/ac/hanyang/engine/DrawManager.java
@@ -1339,7 +1339,7 @@ public final class DrawManager {
             MARGIN + SHIP_SPRITE_BOX_SIZE + MARGIN + VERTICAL_BAR_WIDTH + BAR_MARGIN,
             SCREEN_HEIGHT - UI_HEIGHT + MARGIN);
         drawUltGauge(gameScreen, ship);
-        drawLives(hp, maxHp, MARGIN + SHIP_SPRITE_BOX_SIZE + MARGIN,
+        drawLives(hp, status.getMaxHp(), MARGIN + SHIP_SPRITE_BOX_SIZE + MARGIN,
             SCREEN_HEIGHT - UI_HEIGHT + MARGIN);
         drawLevel(gameScreen, MARGIN + 5, SCREEN_HEIGHT - 25);          // 텍스트의 경우 미관 상 마진에 5픽셀을 더함
         drawSurvivalTime(gameScreen, MARGIN + 5, SCREEN_HEIGHT - 50);


### PR DESCRIPTION
## 개요

- 최대 체력 증가 아이템 획득 시 체력 바가 비정상적으로 그려지는 문제를 해결했습니다.

## 변경사항

- DrawManager.drawLives() 메서드에 전달되는 최대 체력 인수를 GameScreen의 maxHp 속성 대신 Status.getMaxHp()로 대체

## 참고사항

- 관련 이슈 번호: #73 
