### PR TITLE
[BUG_FIX] 관통 총알 지속 대미지 버그 수정

### DIFF
--- a/src/main/java/kr/ac/hanyang/entity/Bullet.java
+++ b/src/main/java/kr/ac/hanyang/entity/Bullet.java
@@ -2,6 +2,7 @@ package kr.ac.hanyang.entity;
 
 import java.awt.Color;
 
+import java.util.ArrayList;
 import kr.ac.hanyang.engine.DrawManager.SpriteType;
 
 /**
@@ -31,6 +32,8 @@ public class Bullet extends Entity {
     private int movement = 0;
     // 총알의 적 관통 여부를 표시
     private boolean isPiercing = false;
+    // 총알이 무시할 적들 (관통 총알용)
+    private ArrayList<EnemyShip> ignoredEnemies = new ArrayList<>();
 
     // 보스 총알인 경우의 속도
     private double speedX;
@@ -283,5 +286,9 @@ public class Bullet extends Entity {
 
     public void setCanMove(boolean move) {
         this.canMove = move;
+    }
+
+    public ArrayList<EnemyShip> getIgnoredEnemies() {
+        return ignoredEnemies;
     }
 }

--- a/src/main/java/kr/ac/hanyang/entity/BulletPool.java
+++ b/src/main/java/kr/ac/hanyang/entity/BulletPool.java
@@ -99,6 +99,9 @@ public final class BulletPool {
      * @param bullet Bullets to recycle.
      */
     public static void recycle(final Set<Bullet> bullet) {
+        for (Bullet b : bullet) {
+            b.getIgnoredEnemies().clear();
+        }
         pool.addAll(bullet);
     }
 }

--- a/src/main/java/kr/ac/hanyang/screen/GameScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/GameScreen.java
@@ -517,13 +517,15 @@ public class GameScreen extends Screen {
             } else { //아군 총알인 경우 실행되는 부분
                 for (EnemyShip enemyShip : enemies) {
                     if (!enemyShip.isDestroyed()
-                        && checkCollision(bullet, enemyShip)) {
+                        && checkCollision(bullet, enemyShip)
+                        && !bullet.getIgnoredEnemies().contains(enemyShip)) {
                         this.shipsDestroyed++;
                         this.enemyShipSet.damage_Enemy(enemyShip, bullet.getDamage());
                         // 관통 여부 확인
                         if (!bullet.getisPiercing()) {
                             recyclable.add(bullet); // 관통 아닌 경우 제거
                         }
+                        bullet.getIgnoredEnemies().add(enemyShip);
                         Core.getSoundManager().playBulletHitSound();
                         // 적 함선이 파괴되었을 때 경험치 생성, 궁극기 게이지 증가
                         if (enemyShip.isDestroyed()) {


### PR DESCRIPTION
## 개요

- 관통 총알이 매 프레임마다 적에게 대미지를 입히는 버그를 수정했습니다.
- Bullet 클래스에 `ArrayList<EnemyShip> ignoredEnemies` 속성을 추가해, 한 번 접촉 후 더 이상 대미지를 입히지 않을 적을 저장하도록 했습니다.

## 변경사항

- Bullet.java
  - ignoredEnemies 속성 추가
  - getIgnoredEnemies() 메서드 추가
- BulletPool.java
  - recycle() 메서드에서 각 총알의 ignoredEnemies를 비우는 절차 추가
- GameScreen.java
  - 총알이 적에게 대미지를 주는 조건에 적이 ignoredEnemies에 포함되지 않는 것을 추가
  - 총알이 적에게 접촉한 경우, 그 적을 해당 총알의 ignoredEnemies에 추가

## 참고사항

- 관련 이슈 번호: #46 
