### PR TITLE
[bugFix-70] <bug> 아이템 최대레벨 달성시 게임 크래쉬되는 버그 수정

### DIFF
--- a/src/main/java/kr/ac/hanyang/Item/ItemList.java
+++ b/src/main/java/kr/ac/hanyang/Item/ItemList.java
@@ -40,25 +40,35 @@ public class ItemList {
 
     // 선택화면에 표시하기 위해 무작위로 선택된 아이템 리스트를 얻어오는 메소드
     public List<Item> getSelectedItemList() {
-        // 상점에 나갈 물품 선정 전에 선행 조건 체크 : 최종 레벨까지 업그레이드를 마친 아이템 제외
+        // 상점에 나갈 물품 선정 전에 상점에 나갈 수 있는 최대 레벨이 아닌 물품의 개수 세기
+        int numSelectingItems = 0;
         for (int i = 0; i < items.size(); i++) {
-            if (items.get(i).isMaxLevel()) {
-                items.remove(i);
+            if (!items.get(i).isMaxLevel()) {
+                numSelectingItems++;
             }
         }
         Set<Item> tempItemList = new HashSet<>();
 
         // 나올 수 있는 아이템의 개수가 3개를 초과하는 경우에만 무작위 선정
-        if (items.size() > 3) {
+        if (numSelectingItems > 3) {
             // 아이템을 중복을 허용하지 않고 3개를 선택할 때까지 반복(Set이므로 중복은 허용되지 않음)
             while (tempItemList.size() < 3) {
                 // items 아이템 개수에 맞는 범위에서 인덱스 랜덤 선정
                 int randomIndex = random.nextInt(items.size());
-                tempItemList.add(items.get(randomIndex));
+                // 뽑힌 아이템이 최대 레벨이 아닌 경우에 추가
+                if (!items.get(randomIndex).isMaxLevel()) {
+                    tempItemList.add(items.get(randomIndex));
+                }
             }
         } else {
-            // 아이템이 3개 미만인 경우에는 무작위 선정하지 않고 그대로 반환
-            return items;
+            // 뽑힐 수 있는 아이템이 3개 미만인 경우에는
+            for (int i = 0; i < items.size(); i++) {
+                if (!items.get(i).isMaxLevel()) {
+                    // 최대 레벨이 아닌 아이템만 넣는다.
+                    tempItemList.add(items.get(i));
+                }
+            }
+            return new ArrayList<>(tempItemList);
         }
         return new ArrayList<>(tempItemList);
     }


### PR DESCRIPTION
내용 :
아이템이 최대레벨이 되면 items 배열에서 해당 아이템이 삭제되면서 drawStats 부분과 충돌을 일으키는 부분 해결하였습니다.

보유하고 있는 아이템이 items에서 사라진다는 것도 어색하고 해당 부분이 오류를 일으키기에 items 배열에서 무작위로 3개를 선택하기 전에 아이템을 삭제하지 않고 그 중에 최대레벨이 아닌 아이템만 고르도록 메소드를 개선하였습니다.

이제 items 배열에는 6가지 아이템이 항상 유지되고 있습니다.
거기서 최대레벨이 아닌 아이템만 고르게 됩니다.


    modified:   src/main/java/kr/ac/hanyang/Item/ItemList.java

