### PR TITLE
PauseScreen 에서 Quit 할 때 배경음악 종료

### DIFF
--- a/src/main/java/kr/ac/hanyang/screen/GameScreen.java
+++ b/src/main/java/kr/ac/hanyang/screen/GameScreen.java
@@ -332,6 +332,7 @@ public class GameScreen extends Screen {
                 if (check == 2) {
                     this.returnCode = 0;
                     this.isRunning = false;
+                    Core.getSoundManager().stopBackgroundMusic();
                 }
                 // 일시정지 화면에서 돌아온 후 스페이스바 키 입력을 초기화하여
                 // 돌아오자마자 스페이스바가 눌린 상태로 인식되지 않도록 함


### PR DESCRIPTION
## 개요

- Pause screen을 통해 game screen 종료시 배경음악이 계속 재생되던 버그 수정

## 변경사항

- GameScreen에서 PauseScreen의 returnCode를 받아 Quit일 경우 isRunning을 false로 설정할 때, Core.getSoundManager.stopBackgroundMusic()을 호출하여 배경음악을 종료 후 화면 종료

## 참고사항

- 관련 이슈 번호: #87 
